### PR TITLE
feat(api): support x-www-form-urlencoded input for some endpoints

### DIFF
--- a/lib/doorbell/util.lua
+++ b/lib/doorbell/util.lua
@@ -410,11 +410,28 @@ function _M.truthy(value)
   end
 
   return value == "yes"
+      or value == "on"
       or value == "1"
       or value == "true"
       or value == true
       or value == 1
 end
+
+
+---@param value any
+function _M.falsy(value)
+  if type(value) == "string" then
+    value = value:lower()
+  end
+
+  return value == "no"
+      or value == "off"
+      or value == "0"
+      or value == "false"
+      or value == false
+      or value == 0
+end
+
 
 
 ---@generic T
@@ -501,5 +518,19 @@ function _M.lookup_from_values(t)
 
   return lookup
 end
+
+
+---@param s string
+---@return string[]
+function _M.split_at_comma(s)
+  local items = _M.array()
+  local _ = s:gsub("[^,]+", function(word)
+    word = word:gsub("^%s+", ""):gsub("%s+$", "")
+    table.insert(items, word)
+  end)
+
+  return items
+end
+
 
 return _M

--- a/spec/02-integration/09-approvals-api_spec.lua
+++ b/spec/02-integration/09-approvals-api_spec.lua
@@ -175,6 +175,28 @@ describe("approvals API", function()
 
     end)
 
+    it("supports application/x-www-form-urlencoded", function()
+      local uri = "http://approvals.test/form"
+      local addr = test.random_ipv4()
+      local query = assert_access_not_approved(addr, uri)
+
+      local ttl = 456
+
+      client:reset()
+      client:post("/approvals", {
+        post = {
+          action  = "allow",
+          scope   = "global",
+          subject = "addr",
+          token   = query.token,
+          ttl     = tostring(ttl),
+        },
+      })
+
+      assert.same(201, client.response.status)
+      assert_access_approved(addr, uri)
+    end)
+
   end)
 
   describe("configurable limits", function()

--- a/spec/testing/client.lua
+++ b/spec/testing/client.lua
@@ -36,7 +36,7 @@ local function prepare(req)
     assert(req.body == nil, "request.post and request.body are " ..
                             "mutually exclusive")
 
-    assert(type(req.post) == "table", "reqest.post must be a table")
+    assert(type(req.post) == "table", "request.post must be a table")
 
     req.body = assert(ngx.encode_args(req.post))
     req.headers = req.headers or _M.headers()

--- a/spec/testing/mock-upstream.lua
+++ b/spec/testing/mock-upstream.lua
@@ -141,7 +141,7 @@ local function get_request()
   local content_type = headers["content-type"]
 
   local errors = {}
-  local body = http.request.get_body()
+  local body = http.request.get_raw_body()
   local json = ngx.null
 
   if body and content_type:lower():find("application/json") then
@@ -240,7 +240,7 @@ function mock.prepare()
     return respond(405, { error = "only POST is allowed" })
   end
 
-  local route = http.request.get_json_body(nil, true)
+  local route = http.request.get_json_body("table", true)
   local ok, err = validate(route)
   if not ok then
     return respond(400, { error = err })


### PR DESCRIPTION
This includes type coercion for simple cases:

* number - `"123" => 123`
* string `123 => "123"`
* boolean `"true" | 1 | "yes" => true`
* array `"a,b,c" => [ "a", "b", "c" ]`

This is a naive approach, so there are probably some common form encoding conventions that I have missed, but I can implement those later on as needed.
