### PR TITLE
fix(api): add content-type to allowed CORS headers

### DIFF
--- a/lib/doorbell/http.lua
+++ b/lib/doorbell/http.lua
@@ -299,7 +299,7 @@ do
     header["Access-Control-Expose-Headers"] = nil
 
     header["Access-Control-Allow-Credentials"] = "true"
-    header["Access-Control-Allow-Headers"] = "Authorization, Cookie"
+    header["Access-Control-Allow-Headers"] = "Authorization, Cookie, Content-Type"
   end
 end
 

--- a/spec/02-integration/05-ip-api_spec.lua
+++ b/spec/02-integration/05-ip-api_spec.lua
@@ -37,10 +37,17 @@ describe("IP API", function()
       assert.is_nil(err)
       assert.same(200, res.status)
 
-      assert.response(res).header("access-control-allow-credentials")
-      assert.response(res).header("access-control-allow-headers")
-      assert.response(res).header("access-control-allow-origin")
-      assert.response(res).header("access-control-max-age")
+      local creds = assert.response(res).header("access-control-allow-credentials")
+      assert.same("true", creds)
+
+      local headers = assert.response(res).header("access-control-allow-headers")
+      assert.same("authorization, cookie, content-type", headers:lower())
+
+      local origin = assert.response(res).header("access-control-allow-origin")
+      assert.same("*", origin)
+
+      local age = assert.response(res).header("access-control-max-age")
+      assert.is_number(tonumber(age), "access-control-max-age was not a valid number")
     end)
 
     it("handles CORS pre-flight OPTIONS requests", function()
@@ -48,11 +55,17 @@ describe("IP API", function()
       assert.is_nil(err)
       assert.same(200, res.status)
 
-      assert.response(res).header("access-control-allow-credentials")
-      assert.response(res).header("access-control-allow-headers")
-      assert.response(res).header("access-control-allow-methods")
-      assert.response(res).header("access-control-allow-origin")
-      assert.response(res).header("access-control-max-age")
+      local creds = assert.response(res).header("access-control-allow-credentials")
+      assert.same("true", creds)
+
+      local headers = assert.response(res).header("access-control-allow-headers")
+      assert.same("authorization, cookie, content-type", headers:lower())
+
+      local origin = assert.response(res).header("access-control-allow-origin")
+      assert.same("*", origin)
+
+      local age = assert.response(res).header("access-control-max-age")
+      assert.is_number(tonumber(age), "access-control-max-age was not a valid number")
     end)
 
     it("reacts to the Accept header", function()


### PR DESCRIPTION
Turns out that Content-Type is allowed by default for CORS purposes, but _only_ for the following mime types:

  * application/x-www-form-urlencoded
  * multipart/form-data
  * text/plain

Explicitly allowing it via Access-Control-Allow-Headers opens it up to any mime type.

See also:
  * https://fetch.spec.whatwg.org/#cors-safelisted-request-header
  * https://fetch.spec.whatwg.org/#http-access-control-request-headers