### PR TITLE
chore(*): remove agent process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ ENV DOORBELL_LOG_PATH=${LOG_PREFIX}/doorbell
 COPY ./lib/ ${DOORBELL_LIB_PATH}/
 COPY ./assets/ ${DOORBELL_ASSET_PATH}/
 COPY ./bin/render-nginx-template ${DOORBELL_LIBEXEC_PATH}/
+COPY ./bin/resty-doorbell ${DOORBELL_LIBEXEC_PATH}/
 
 ARG NGINX_USER=doorbell
 ARG NGINX_USER_ID=9876

--- a/assets/nginx.include/main.thread-pools.conf
+++ b/assets/nginx.include/main.thread-pools.conf
@@ -1,0 +1,2 @@
+thread_pool "doorbell.json.log"  threads=16 max_queue=1024;
+thread_pool "doorbell.util.file" threads=16 max_queue=1024;

--- a/assets/nginx.template.conf
+++ b/assets/nginx.template.conf
@@ -6,8 +6,6 @@ pcre_jit on;
 
 error_log ${LOG_PATH}/error.log ${LOG_LEVEL};
 
-thread_pool "doorbell.json.log" threads=16 max_queue=1024;
-
 include "${ASSET_PATH}/nginx.include/main.*.conf";
 include               "nginx.include.main.*.conf";
 ${NGINX_MAIN}

--- a/bin/busted
+++ b/bin/busted
@@ -3,9 +3,7 @@
 export _DOORBELL_TEST=1
 
 exec -a busted \
-    resty \
+    "$PWD/bin/resty-doorbell" \
     -I "$PWD/lib" \
     -I "$PWD" \
-    --no-stream \
-    --http-include "./assets/nginx.include/http.shm.conf" \
     ./spec/busted "$@"

--- a/bin/resty-doorbell
+++ b/bin/resty-doorbell
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+readonly ASSET_DIR=${DOORBELL_ASSET_PATH:-$PWD/assets}
+readonly LIB_DIR=${DOORBELL_LIB_PATH:-$PWD/lib}
+
+ARGS=()
+
+for f in "$ASSET_DIR"/nginx.include/http*.conf; do
+    ARGS+=(--http-include "$f")
+done
+
+for f in "$ASSET_DIR"/nginx.include/main*.conf; do
+    ARGS+=(--main-include "$f")
+done
+
+
+exec resty \
+    -I "$LIB_DIR" \
+    --no-stream \
+    "${ARGS[@]}" \
+    "$@"

--- a/doorbell-dev-1.rockspec
+++ b/doorbell-dev-1.rockspec
@@ -78,6 +78,7 @@ build = {
     ["doorbell.shm"] = "lib/doorbell/shm.lua",
 
     ["doorbell.util"] = "lib/doorbell/util.lua",
+    ["doorbell.util.file"] = "lib/doorbell/util/file.lua",
 
     ["doorbell.views"] = "lib/doorbell/views.lua",
     ["doorbell.views.answer"] = "lib/doorbell/views/answer.lua",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,7 @@ if [[ ${1:-} = start ]]; then
         "${DOORBELL_LOG_PATH}/doorbell.json.log"
 
     echo "Rendering NGINX template to ${DOORBELL_RUNTIME_PATH}/nginx.conf"
+    "$DOORBELL_LIBEXEC_PATH"/resty-doorbell \
     "$DOORBELL_LIBEXEC_PATH"/render-nginx-template \
         < "$DOORBELL_ASSET_PATH"/nginx.template.conf \
         > "$DOORBELL_RUNTIME_PATH"/nginx.conf

--- a/lib/doorbell.lua
+++ b/lib/doorbell.lua
@@ -24,6 +24,7 @@ local middleware = require "doorbell.middleware"
 local nginx = require "doorbell.nginx"
 
 local ngx        = ngx
+local var        = ngx.var
 local assert     = assert
 local send       = http.send
 local new_ctx    = request.new
@@ -182,7 +183,10 @@ end
 
 function _M.status()
   http.response.set_header("content-type", "application/json")
-  http.send(200, nginx.info())
+  local block = tonumber(var.arg_block)
+  local info = nginx.info(block)
+  local status = info.ok and 200 or 503
+  http.send(status, info)
 end
 
 

--- a/lib/doorbell.lua
+++ b/lib/doorbell.lua
@@ -73,16 +73,6 @@ local submodules = {
   routes,
 }
 
-local function init_agent()
-  for _, mod in ipairs(submodules) do
-    local handler = rawget(mod, "init_agent") or rawget(mod, "init_worker")
-    if type(handler) == "function" then
-      handler()
-    end
-  end
-end
-
-
 function _M.init()
   nginx.init()
   env.init()
@@ -105,14 +95,9 @@ function _M.init_worker()
 
   nginx.init_worker()
 
-  if nginx.process.is_agent then
-    init_agent()
-
-  else
-    for _, mod in ipairs(submodules) do
-      if type(mod.init_worker) == "function" then
-        mod.init_worker()
-      end
+  for _, mod in ipairs(submodules) do
+    if type(mod.init_worker) == "function" then
+      mod.init_worker()
     end
   end
 end

--- a/lib/doorbell/api/nginx.lua
+++ b/lib/doorbell/api/nginx.lua
@@ -42,10 +42,6 @@ routes["/nginx"] = {
           end
         end
 
-        if not info.agent.healthy then
-          healthy = false
-        end
-
         if not healthy then
           ngx.sleep(0.05)
         end

--- a/lib/doorbell/api/nginx.lua
+++ b/lib/doorbell/api/nginx.lua
@@ -21,36 +21,9 @@ routes["/nginx"] = {
 
   GET = function(ctx)
     local block = tonumber(request.get_query_arg(ctx, "block"))
-
-    if block and block > 0 then
-      ngx.update_time()
-      local start = ngx.now()
-      local deadline = start + block
-      local info
-      local tries = 0
-
-      repeat
-        tries = tries + 1
-        local healthy = true
-
-        info = nginx.info()
-
-        for i = 1, ngx.worker.count() do
-          healthy = info.workers[i] and info.workers[i].healthy
-          if not healthy then
-            break
-          end
-        end
-
-        if not healthy then
-          ngx.sleep(0.05)
-        end
-      until healthy or ngx.now() > deadline
-
-      return http.send(200, info)
-    end
-
-    return http.send(200, nginx.info())
+    local info = nginx.info(block)
+    local status = info.ok and 200 or 503
+    return http.send(status, info)
   end,
 }
 

--- a/lib/doorbell/ota.lua
+++ b/lib/doorbell/ota.lua
@@ -187,9 +187,11 @@ function _M.init(conf)
 end
 
 
-function _M.init_agent()
+function _M.init_worker()
   if not config then return end
-  assert(ngx.timer.at(0, update_timer))
+  if ngx.worker.id() == 0 then
+    assert(ngx.timer.at(0, update_timer))
+  end
 end
 
 

--- a/lib/doorbell/request/file-logger.lua
+++ b/lib/doorbell/request/file-logger.lua
@@ -1,11 +1,11 @@
 local _M = {}
 
-local ffi = require "ffi"
-local cjson    = require("cjson.safe").new()
-local encode   = cjson.encode
-local fmt      = string.format
-local concat   = table.concat
-local insert   = table.insert
+local ffi    = require "ffi"
+local cjson  = require("cjson.safe").new()
+local encode = cjson.encode
+local fmt    = string.format
+local concat = table.concat
+local insert = table.insert
 
 cjson.encode_keep_buffer(true)
 cjson.encode_number_precision(16)

--- a/lib/doorbell/rules/stats.lua
+++ b/lib/doorbell/rules/stats.lua
@@ -272,9 +272,11 @@ local function saver(premature, interval)
 end
 
 
-function _M.init_agent()
-  SEMAPHORE = assert(require("ngx.semaphore").new(1))
-  assert(timer_at(0, saver, 1))
+function _M.init_worker()
+  if ngx.worker.id() == 0 then
+    SEMAPHORE = assert(require("ngx.semaphore").new(1))
+    assert(timer_at(0, saver, 1))
+  end
 end
 
 

--- a/lib/doorbell/util/file.lua
+++ b/lib/doorbell/util/file.lua
@@ -4,7 +4,7 @@ local _M = {}
 local rand_bytes = require("resty.random").bytes
 local to_hex = require("resty.string").to_hex
 
-local cjson = require("cjson").new()
+local cjson = require("cjson.safe").new()
 cjson.encode_keep_buffer(true)
 cjson.encode_number_precision(16)
 cjson.encode_escape_forward_slash(false)
@@ -116,25 +116,42 @@ _M.read = read
 ---@param fname string
 ---@param data string
 ---@return boolean? ok
+---@return string? error
 function _M.write_json(fname, data)
-  return write(fname, encode(data))
+  local encoded, err = encode(data)
+  if err then
+    return nil, err
+  end
+
+  return write(fname, encoded)
 end
 
 
 ---@param fname string
 ---@param data string
----@return boolean ok
+---@return boolean? ok
 ---@return nil
 ---@return boolean written
 function _M.update_json(fname, data)
-  return update(fname, encode(data))
+  local encoded, err = encode(data)
+  if err then
+    return nil, err, false
+  end
+
+  return update(fname, encoded)
 end
 
 
 ---@param fname string
----@return any
+---@return any? json
+---@return string? error
 function _M.read_json(fname)
-  return decode(read(fname))
+  local contents, err = read(fname)
+  if not contents then
+    return nil, err
+  end
+
+  return decode(contents)
 end
 
 

--- a/lib/doorbell/util/file.lua
+++ b/lib/doorbell/util/file.lua
@@ -1,0 +1,141 @@
+---@class doorbell.util.file
+local _M = {}
+
+local rand_bytes = require("resty.random").bytes
+local to_hex = require("resty.string").to_hex
+
+local cjson = require("cjson").new()
+cjson.encode_keep_buffer(true)
+cjson.encode_number_precision(16)
+cjson.encode_escape_forward_slash(false)
+
+
+local open = io.open
+local encode = cjson.encode
+local decode = cjson.decode
+local rename = os.rename
+local remove = os.remove
+local md5 = ngx.md5_bin
+
+---@return string
+local function rand_suffix()
+  local bytes = rand_bytes(8, false)
+  return "." .. to_hex(bytes)
+end
+
+
+---@param fname string
+---@param data string
+---@return boolean? ok
+---@return string? error
+local function write(fname, data)
+  local fh, err = open(fname, "w+")
+  if not fh then
+    return nil, err
+  end
+
+  local ok
+  ok, err = fh:write(data)
+
+  fh:close()
+
+  if not ok then
+    return nil, err
+  end
+
+  return true
+end
+
+
+---@param fname string
+---@return string? contents
+---@return string? error
+local function read(fname)
+  local fh, err = open(fname, "r")
+  if not fh then
+    return nil, err
+  end
+
+  local content
+  content, err = fh:read("*a")
+  fh:close()
+
+  if err or not content then
+    return nil, err
+  end
+
+  return content
+end
+
+---@param fname string
+---@return string?
+local function md5_file(fname)
+  local content = read(fname)
+  if content then
+    return md5(content)
+  end
+end
+
+
+---@param fname string
+---@param data string
+---@return boolean? ok
+---@return string? error
+---@return boolean written
+local function update(fname, data)
+  local checksum = md5_file(fname)
+  if checksum and checksum == md5(data) then
+    return true, nil, false
+  end
+
+  local temp = fname .. rand_suffix()
+
+  local ok, err
+
+  ok, err = write(temp, data)
+  if not ok then
+    return nil, err, false
+  end
+
+  ok, err = rename(temp, fname)
+  if not ok then
+    -- we don't know if our temp file still exists, so ignore errors
+    remove(temp)
+
+    return nil, err, false
+  end
+
+  return true, nil, true
+end
+
+
+_M.write = write
+_M.update = update
+_M.read = read
+
+---@param fname string
+---@param data string
+---@return boolean? ok
+function _M.write_json(fname, data)
+  return write(fname, encode(data))
+end
+
+
+---@param fname string
+---@param data string
+---@return boolean ok
+---@return nil
+---@return boolean written
+function _M.update_json(fname, data)
+  return update(fname, encode(data))
+end
+
+
+---@param fname string
+---@return any
+function _M.read_json(fname)
+  return decode(read(fname))
+end
+
+
+return _M

--- a/spec/01-unit/04-util_spec.lua
+++ b/spec/01-unit/04-util_spec.lua
@@ -1,4 +1,6 @@
 local util = require "doorbell.util"
+local cjson = require "cjson"
+local lfs = require "lfs"
 
 describe("doorbell.util", function()
   describe("current_time()", function()
@@ -83,6 +85,121 @@ describe("doorbell.util", function()
     it("sorts its output", function()
       assert.same({ "a", "b" }, util.table_keys({ b = 1, a = 2 }))
     end)
+  end)
 
+  describe("sha256()", function()
+    it("returns a sh256 checksum in hexadecimal form", function()
+      assert.same("c0ddd62c7717180e7ffb8a15bb9674d3ec92592e0b7ac7d1d5289836b4553be2",
+                  util.sha256("hi!"))
+    end)
+  end)
+
+  describe("split_at_comma()", function()
+    it("splits a string into a table", function()
+      assert.same({"a", "b", "c"}, util.split_at_comma("a,b,c"))
+    end)
+
+    it("strips whitespace from each item", function()
+      assert.same({"a", "b", "c"}, util.split_at_comma(" a ,b,   c"))
+    end)
+
+    it("returns a table with a single item when no comma is found", function()
+      assert.same({"abc"}, util.split_at_comma("abc"))
+    end)
+
+    it("sets the cjson array metatable on the output", function()
+      assert.equals(cjson.array_mt, getmetatable(util.split_at_comma("a,b,c")))
+    end)
+  end)
+
+  describe("join()", function()
+    it("joins filesystem path elements", function()
+      assert.equals("a/b/c", util.join("a", "b", "c"))
+    end)
+
+    it("does not produce duplicate separators", function()
+      assert.equals("a/b/c", util.join("a/", "/b/", "c"))
+    end)
+
+    it("does not produce a trailing separator", function()
+      assert.equals("a/b/c", util.join("a/", "/b/", "c/"))
+      assert.equals("a/b/c", util.join("a/", "/b/", "c////"))
+
+      -- eh, not so sure about this one
+      assert.equals("a/b/c", util.join("a/", "/b/", "c", ""))
+    end)
+
+    it("does not mangle args with multiple path elements", function()
+      assert.equals("a/b/subdir/c", util.join("a", "b/subdir/", "c"))
+    end)
+
+    it("does not mangle relative paths", function()
+      assert.equals("./a/b/c", util.join("./a", "b/c"))
+      assert.equals("./a/b/c", util.join(".//a", "b/c"))
+      assert.equals("./a/b/../c", util.join(".//a", "b", "..", "c"))
+      assert.equals("./a/b/../c", util.join(".//a", "b", "../", "c"))
+      assert.equals("./a/b/../c", util.join(".//a", "b", "../", "/c/"))
+      assert.equals("./a/b/../c", util.join(".//a//", "b", "../c/"))
+    end)
+
+
+    it("handles absolute paths", function()
+      assert.equals("/a/b/c", util.join("/a", "b", "c"))
+      assert.equals("/a/b/c", util.join("/", "a", "b", "c"))
+    end)
+  end)
+
+  describe("update_json_file()", function()
+    it("writes json to a file", function()
+      local f = os.tmpname()
+      assert(util.update_json_file(f, { a = 1, b = 2 }))
+      assert.same({ a = 1, b = 2 }, util.read_json_file(f))
+    end)
+
+    it("only writes the file if changes are made", function()
+      local f = os.tmpname()
+      local j = { a = 1, b = 2 }
+      assert(util.update_json_file(f, j))
+      assert.same(j, util.read_json_file(f))
+
+      local init = lfs.attributes(f)
+
+      local ok, err, written = util.update_json_file(f, j)
+      assert.is_nil(err)
+      assert.truthy(ok)
+      assert.is_false(written)
+      assert.same(j, util.read_json_file(f))
+
+      local no_update = lfs.attributes(f)
+      assert.equals(init.ino, no_update.ino)
+      assert.equals(init.modification, no_update.modification)
+
+      j.c = 3
+      ok, err, written = util.update_json_file(f, j)
+      assert.is_nil(err)
+      assert.truthy(ok)
+      assert.is_true(written)
+      assert.same(j, util.read_json_file(f))
+
+      local update = lfs.attributes(f)
+      assert.not_equals(init.ino, update.ino)
+      -- not doing a mod time check here because I don't want to
+      -- add a sleep to this test suite
+      -- assert.not_equals(init.modification, update.modification)
+
+      ok, err, written = util.update_json_file(f, j)
+      assert.is_nil(err)
+      assert.truthy(ok)
+      assert.is_false(written)
+      assert.same(j, util.read_json_file(f))
+
+      assert(util.write_file(f, "I've changed!"))
+
+      ok, err, written = util.update_json_file(f, j)
+      assert.is_nil(err)
+      assert.truthy(ok)
+      assert.is_true(written)
+      assert.same(j, util.read_json_file(f))
+    end)
   end)
 end)

--- a/spec/02-integration/10-prometheus-metrics_spec.lua
+++ b/spec/02-integration/10-prometheus-metrics_spec.lua
@@ -610,11 +610,7 @@ describe("prometheus metrics", function()
       api:get("/nginx", { query = { block = 1 } })
       local info = api.response.json
 
-      local agent_before = await_metric.value(name, { type = "agent" })
       local worker_before = await_metric.value(name, { type = "worker" })
-
-      assert(signal.kill(info.agent.pid, 9))
-      await_metric.gt(name, { type = "agent" }, agent_before)
 
       assert(signal.kill(info.workers[1].pid, 9))
       await_metric.gt(name, { type = "worker" }, worker_before)

--- a/spec/02-integration/11-nginx-api_spec.lua
+++ b/spec/02-integration/11-nginx-api_spec.lua
@@ -61,7 +61,6 @@ describe("nginx api", function()
     local info = assert.is_table(client.response.json)
 
     assert.table_shape({
-      agent        = "table",
       group        = "number",
       started      = "number",
       uptime       = "number",
@@ -77,14 +76,6 @@ describe("nginx api", function()
       respawn_count = "number",
       started       = "number",
     }, info.workers[1])
-
-    assert.table_shape({
-      id            = "number",
-      last_seen     = "number",
-      pid           = "number",
-      respawn_count = "number",
-      started       = "number",
-    }, info.agent)
   end)
 
   it("updates with each heartbeat", function()
@@ -95,10 +86,6 @@ describe("nginx api", function()
     test.await.truthy(function()
       client:get("/nginx")
       local new = assert.is_table(client.response.json)
-
-      if new.agent.last_seen <= info.agent.last_seen then
-        return false
-      end
 
       if #new.workers ~= info.worker_count then
         return false
@@ -183,10 +170,6 @@ describe("nginx api", function()
     end, 5, 0.1)
 
     assert.is_true(new.group > old.group)
-
-    assert.same(old.agent.id, new.agent.id)
-    assert.not_same(old.agent.pid, new.agent.pid)
-    assert.same(0, new.agent.respawn_count)
 
     for i = 1, old.worker_count do
       assert.same(old.workers[i].id, new.workers[i].id)

--- a/spec/02-integration/11-nginx-api_spec.lua
+++ b/spec/02-integration/11-nginx-api_spec.lua
@@ -33,7 +33,9 @@ describe("nginx api", function()
   end)
 
   before_each(function()
-    client.assert_status.GET = nil
+    nginx:restart()
+
+    client.assert_status.GET = { one_of = { 200, 503 } }
     client.raise_on_request_error = false
     client.raise_on_connect_error = false
 
@@ -46,7 +48,6 @@ describe("nginx api", function()
 
     client:reset()
 
-    client.assert_status.GET = { eq = 200 }
     client.raise_on_request_error = true
     client.raise_on_connect_error = true
   end)
@@ -136,10 +137,9 @@ describe("nginx api", function()
 
   it("updates when nginx is reloaded", function()
     client:get("/nginx")
-
     local old = assert.is_table(client.response.json)
 
-    nginx:reload()
+    nginx:reload(true)
 
     local new
 


### PR DESCRIPTION
This moves most file I/O out of the agent process and into worker processes where we can use `ngx.run_worker_thread()`.

Without `ngx.run_worker_thread()`, I can't really use the agent process for anything meaningful right now. Maybe there will be a reason to bring it back later on.